### PR TITLE
Change "wm" to "Margin"

### DIFF
--- a/window-margin.el
+++ b/window-margin.el
@@ -59,7 +59,7 @@ percentage of the frame width.")
 (make-local-variable 'window-margin-width)
 (setq-default window-margin-width nil)
 
-(defcustom window-margin-mode-line-string " wm"
+(defcustom window-margin-mode-line-string " Margin"
   "String displayed on the modeline when window-margin is active.
 Set this to nil if you don't want a modeline indicator."
   :group 'window-margin


### PR DESCRIPTION
This PR changes the "wm" mode line to "Margin" which is more consistent with other mode lines. (Namely, that they tend to be short words, with an initial cap.)

For example, at the moment, using org mode, I see this:

```
(Org wm Wrap)
```

With this change, I would see:

```
(Org Margin Wrap)
```
