### PR TITLE
Change text-mode to text-mode-hook

### DIFF
--- a/window-margin.el
+++ b/window-margin.el
@@ -31,7 +31,7 @@
 ;;
 ;; To enable it with text-mode use:
 ;;
-;;   (add-hook 'text-mode 'turn-on-window-margin-mode)
+;;   (add-hook 'text-mode-hook 'turn-on-window-margin-mode)
 ;;
 ;; This minor mode was inspired by reading an entry on StackOverflow
 ;;


### PR DESCRIPTION
The documentation tells you to use:

```
(add-hook 'text-mode 'turn-on-window-margin-mode)
```

But this doesn't work. It should be:

```
(add-hook 'text-mode-hook 'turn-on-window-margin-mode)
```

I've changed this in `window-margin.el` only, because I have another PR outstanding that changes README. Let me know if you'd like me to merge in the changes from #4.
